### PR TITLE
Update package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ We are following [JavaScript Standard Style](https://standardjs.com), with [some
 
 ## Installation
 ```
-yarn add --dev eslint@^4.19.1 @glossier/eslint-config
+yarn add --dev eslint@^4.19.1 @glossier/eslint-config-frontend
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To get started, extend Glossier's configuration in your `.eslintrc`.
 
 ```
 {
-  "extends": "@glossier"
+  "extends": "@glossier/frontend"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@glossier/eslint-configuration",
+  "name": "@glossier/eslint-config-frontend",
   "version": "3.4.0",
   "description": "How we write JavaScript at Glossier",
   "main": "index.js",


### PR DESCRIPTION
Updating our package name to `eslint-config-frontend` due to conflicts with GitHub package names on GV2. 
